### PR TITLE
_config.yml Patch-001 (20.01.20)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,9 @@
-<h1> Conrad, podoba Ci się stronka? kruszwolt, oj sry wymskenlo mi sie </h1>
-
-theme: jekyll-theme-merlot
+<!DOCTYPE html>
+<html>
+  <head>
+    theme: jekyll-theme-merlot
+    <h1> Conrad, podoba Ci się stronka? kruszwolt, oj sry wymskenlo mi sie </h1>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
Dodałem podstawowy szkielet HTML w nadziei, że błąd 3 linijki opisany na WhyNot Group (związany z "theme: jeklyy-theme-merlot" zniknie.